### PR TITLE
Move episode files to their own folder

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,13 +1,11 @@
 const util = require('util')
 
 module.exports = (config) => {
-  config.addCollection(
-    'episodes',
-    (collectionApi) =>
-      collectionApi
-        .getFilteredByGlob('./content/*.md')
-        .filter((page) => /^\d+$/.test(page.fileSlug)) // Check if file name is number
-        .reverse() // Newest first
+  config.addCollection('episodes', (collectionApi) =>
+    collectionApi
+      .getFilteredByGlob('./content/episodes/*.md')
+      // Newest first
+      .reverse()
   )
 
   config.addFilter('console', (value) => util.inspect(value))

--- a/content/episodes/1.md
+++ b/content/episodes/1.md
@@ -1,8 +1,7 @@
 ---
-title: 1 - Windows powertools & Firefox extensions
+title: 'Windows powertools & Firefox extensions'
 description: Ensimmäinen episodi juhuu!
 date: 2021-01-01
-layout: episode
 ---
 
 CONTENTTIA

--- a/content/episodes/2.md
+++ b/content/episodes/2.md
@@ -1,8 +1,7 @@
 ---
-title: '2 – Ergo part 1: näppäimistöhifistelyä'
+title: 'Ergo part 1: näppäimistöhifistelyä'
 description: Filters are used to transform or modify content. You can add Nunjucks specific filters, but you probably want to add a Universal filter instead.
 date: 2021-01-01
-layout: episode
 ---
 
 swäggiä

--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -1,0 +1,7 @@
+module.exports = {
+  layout: 'episode',
+  eleventyComputed: {
+    permalink: (data) => `/${data.page.fileSlug}/`,
+    title: (data) => `${data.page.fileSlug} &ndash; ${data.title}`,
+  },
+}

--- a/layouts/episode.njk
+++ b/layouts/episode.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1>
-    {{ title }}
+    {{ title | safe }}
 </h1>
 
 <p>

--- a/layouts/index.njk
+++ b/layouts/index.njk
@@ -57,7 +57,7 @@
           <a
             href="{{ episode.url }}"
             class="hover:text-red-500 active:text-red-700"
-            >{{ episode.data.title }}</a
+            >{{ episode.data.title | safe }}</a
           >
         </h3>
         <footer>


### PR DESCRIPTION
Benefits:

- Clearer structure in the `content` folder
- Episode files won't be confused with `404.md` (not found page; doesn't exist yet)
- Common data can be specified in `episodes.11tydata.js` (see [_Template and Directory Specific Data Files_ at 11ty docs](https://www.11ty.dev/docs/data-template-dir/))