### PR TITLE
Update 11ty config

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,3 @@
-const util = require('util')
-
 module.exports = (config) => {
   config.addCollection('episodes', (collectionApi) =>
     collectionApi
@@ -8,11 +6,33 @@ module.exports = (config) => {
       .reverse()
   )
 
-  config.addFilter('console', (value) => util.inspect(value))
+  // See https://browsersync.io/docs/options for all options
+  config.setBrowserSyncConfig({
+    // > Clicks, scrolls & form inputs on any device
+    // > will be mirrored to all others.
+    // Annoying feature
+    ghostMode: false,
+
+    // Enable to create a public URL (`https://something-random.loca.lt/`);
+    // useful when testing on mobile devices
+    tunnel: false,
+
+    // > Browsersync includes a user-interface
+    // > that is accessed via a separate port.
+    // > The UI allows to controls all devices,
+    // > push sync updates
+    // > and much more.
+    // Not needed
+    ui: false,
+  })
+
+  // Defaults to true in Eleventy 1.0
+  config.setDataDeepMerge(true)
 
   return {
     dir: {
       input: 'content',
+
       // These are relative to the input dir
       data: '../data',
       includes: '../layouts',


### PR DESCRIPTION
\+ remove the console filter. We can instead use [11ty's default `log` filter](https://www.11ty.dev/docs/filters/log/) which logs to the terminal.