### PR TITLE
Install `sexy-require` for absolute `require()` paths

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,5 @@
+require('sexy-require')
+
 module.exports = (config) => {
   config.addCollection('episodes', (collectionApi) =>
     collectionApi

--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -1,4 +1,4 @@
-const char = require('../../data/char')
+const char = require('/data/char')
 
 module.exports = {
   layout: 'episode',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@11ty/eleventy": "^0.12.1"
+        "@11ty/eleventy": "^0.12.1",
+        "sexy-require": "^1.1.2"
       },
       "devDependencies": {
         "prettier": "2.3.1",
@@ -3194,6 +3195,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "node_modules/sexy-require": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sexy-require/-/sexy-require-1.1.2.tgz",
+      "integrity": "sha512-NPbWT9MfkmJvtXwfrIh02462x1GJ1L59AF5FGsurmpHdvCTaIytFPdSCM2N86MV4oK2nbRNVenyijKS+kseSZQ=="
+    },
     "node_modules/shortid": {
       "version": "2.2.16",
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
@@ -6265,6 +6271,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "sexy-require": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sexy-require/-/sexy-require-1.1.2.tgz",
+      "integrity": "sha512-NPbWT9MfkmJvtXwfrIh02462x1GJ1L59AF5FGsurmpHdvCTaIytFPdSCM2N86MV4oK2nbRNVenyijKS+kseSZQ=="
     },
     "shortid": {
       "version": "2.2.16",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "start": "npm run clean && npx @11ty/eleventy --serve"
   },
   "dependencies": {
-    "@11ty/eleventy": "^0.12.1"
+    "@11ty/eleventy": "^0.12.1",
+    "sexy-require": "^1.1.2"
   },
   "devDependencies": {
     "prettier": "2.3.1",


### PR DESCRIPTION
Will be more useful in the future. Multiple `../` in paths are annoying.

Love the name "Sultan's `sexy-require`." 😃