### PR TITLE
Replace Sultan's `sexy-require` with Basetag

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,3 @@
-require('sexy-require')
-
 require('./patchPreact')
 
 const fs = require('fs')

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ In VS Code,
 open the command palette (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>),
 choose "Extensions: Show Recommended Extensions"
 and install the recommended extensions.
+
+If you get errors like "Cannot find module `'$/data/char'`,"
+re-run `npm install`.
+(The `postinstall` script will automatically setup [Basetag][basetag]
+for absolute import paths.)
+
+[basetag]: https://github.com/janniks/basetag

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ and install the recommended extensions.
 If you get errors like "Cannot find module `'$/data/char'`,"
 re-run `npm install`.
 (The `postinstall` script will automatically setup [Basetag][basetag]
-for absolute import paths.)
+which adds support for absolute import paths.)
 
 [basetag]: https://github.com/janniks/basetag

--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -1,5 +1,5 @@
-const char = require('/data/char')
-const { isProdEnv, isScheduled } = require('/data/utils')
+const char = require('$/data/char')
+const { isProdEnv, isScheduled } = require('$/data/utils')
 
 const getAdjacentEpisode = (offset) => (data) => {
   const { episodes } = data.collections

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,16 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
         "@11ty/eleventy": "^0.12.1",
         "@heroicons/react": "^1.0.1",
+        "basetag": "^2.0.1",
         "cross-env": "^7.0.3",
         "htm": "^3.0.4",
         "preact": "^10.5.13",
         "preact-render-to-string": "^5.1.19",
-        "react": "^17.0.2",
-        "sexy-require": "^1.1.2"
+        "react": "^17.0.2"
       },
       "devDependencies": {
         "prettier": "2.3.1"
@@ -325,6 +326,17 @@
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/basetag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basetag/-/basetag-2.0.1.tgz",
+      "integrity": "sha512-ety87wDZQ04xAPqOvJNeXl2BibKzxp8+tTg84a3fPdXyfnOwM8Lbd810+BIT594lJG/MzbwULgQ+iY919OZRag==",
+      "bin": {
+        "basetag": "bin/index.js",
+        "basetag-debase": "bin/debase.js",
+        "basetag-link": "bin/link.js",
+        "basetag-rebase": "bin/rebase.js"
       }
     },
     "node_modules/batch": {
@@ -2948,11 +2960,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
-    "node_modules/sexy-require": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sexy-require/-/sexy-require-1.1.2.tgz",
-      "integrity": "sha512-NPbWT9MfkmJvtXwfrIh02462x1GJ1L59AF5FGsurmpHdvCTaIytFPdSCM2N86MV4oK2nbRNVenyijKS+kseSZQ=="
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3774,6 +3781,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+    },
+    "basetag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basetag/-/basetag-2.0.1.tgz",
+      "integrity": "sha512-ety87wDZQ04xAPqOvJNeXl2BibKzxp8+tTg84a3fPdXyfnOwM8Lbd810+BIT594lJG/MzbwULgQ+iY919OZRag=="
     },
     "batch": {
       "version": "0.6.1",
@@ -5822,11 +5834,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
-    "sexy-require": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sexy-require/-/sexy-require-1.1.2.tgz",
-      "integrity": "sha512-NPbWT9MfkmJvtXwfrIh02462x1GJ1L59AF5FGsurmpHdvCTaIytFPdSCM2N86MV4oK2nbRNVenyijKS+kseSZQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,17 +2,18 @@
   "scripts": {
     "build": "npm run clean && cross-env NODE_ENV=production npx @11ty/eleventy",
     "clean": "rm -rf ./_site/",
+    "postinstall": "npx basetag link --hook",
     "start": "npm run clean && cross-env NODE_ENV=development npx @11ty/eleventy --serve"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",
     "@heroicons/react": "^1.0.1",
+    "basetag": "^2.0.1",
     "cross-env": "^7.0.3",
     "htm": "^3.0.4",
     "preact": "^10.5.13",
     "preact-render-to-string": "^5.1.19",
-    "react": "^17.0.2",
-    "sexy-require": "^1.1.2"
+    "react": "^17.0.2"
   },
   "devDependencies": {
     "prettier": "2.3.1"

--- a/views/components/Base.js
+++ b/views/components/Base.js
@@ -1,6 +1,6 @@
 const { html } = require('htm/preact')
 
-const char = require('/data/char')
+const char = require('$/data/char')
 const loadComponent = require('../loadComponent')
 
 const Link = loadComponent('Link')

--- a/views/layouts/Episode.11ty.js
+++ b/views/layouts/Episode.11ty.js
@@ -1,6 +1,6 @@
 const { html } = require('htm/preact')
 
-const char = require('/data/char')
+const char = require('$/data/char')
 const loadComponent = require('../loadComponent')
 
 const Base = loadComponent('Base')

--- a/views/layouts/Home.11ty.js
+++ b/views/layouts/Home.11ty.js
@@ -1,6 +1,6 @@
 const { html } = require('htm/preact')
 
-const char = require('/data/char')
+const char = require('$/data/char')
 const loadComponent = require('../loadComponent')
 
 const Base = loadComponent('Base')

--- a/views/loadComponent.js
+++ b/views/loadComponent.js
@@ -16,7 +16,7 @@
  * const Base = loadComponent('Base')
  *
  * // Basically the same as:
- * const Base = require('/views/components/Base')
+ * const Base = require('$/views/components/Base')
  * // ...but without cache
  */
 module.exports = function loadComponent(name) {


### PR DESCRIPTION
RIP Sultan's `sexy-require`, it was nice while it lasted 😔, but I now love Basetag more¹.

¹ See [How to use absolute import paths in Node.js](https://mtsknn.fi/blog/how-to-use-absolute-import-paths-in-nodejs/) for why Basetag is better.