### PR TITLE
Enforce usage of Node.js 14 and npm 7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build.environment]
+  NODE_ENV = "production"
+  NODE_VERSION = "14"
+  NPM_VERSION = "7"

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   },
   "devDependencies": {
     "prettier": "2.3.1"
+  },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
   }
 }


### PR DESCRIPTION
Hat tip to Stefan Judis: [Prevent npm install for not supported Node.js versions](https://www.stefanjudis.com/today-i-learned/prevent-npm-install-for-not-supported-node-js-versions/)

\+ configure Netlify to use those versions.