### PR TITLE
Fix scheduled episodes breaking build

### DIFF
--- a/views/components/Base.js
+++ b/views/components/Base.js
@@ -27,7 +27,7 @@ const Header = ({ currentUrl }) => {
                 <${Link}
                   class=${tw(
                     linkClasses,
-                    currentUrl.startsWith(href) && 'font-bold'
+                    currentUrl.startsWith?.(href) && 'font-bold'
                   )}
                   href=${href}
                 >


### PR DESCRIPTION
`page.url` is `false` → `page.url.startsWith` is not a function