### PR TITLE
Fix sitemap

### DIFF
--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -1,13 +1,15 @@
 const char = require('$/data/char')
 const { isProdEnv, isScheduled } = require('$/data/utils')
 
-const getAdjacentEpisode = (offset) => (data) => {
+const adjacentEpisode = (data, offset) => {
   const { episodes } = data.collections
   const { url: currentUrl } = data.page
 
   const currentIndex = episodes.findIndex(({ url }) => url === currentUrl)
   return episodes[currentIndex + offset]
 }
+const nextEpisode = (data) => adjacentEpisode(data, -1)
+const previousEpisode = (data) => adjacentEpisode(data, +1)
 
 const permalink = (data) =>
   isProdEnv() && isScheduled(data) ? false : `/${data.page.fileSlug}/`
@@ -18,9 +20,9 @@ const title = (data) =>
 module.exports = {
   layout: 'Episode',
   eleventyComputed: {
-    nextEpisode: getAdjacentEpisode(-1),
+    nextEpisode,
     permalink,
-    previousEpisode: getAdjacentEpisode(+1),
+    previousEpisode,
     title,
   },
 }

--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -9,18 +9,18 @@ const getAdjacentEpisode = (offset) => (data) => {
   return episodes[currentIndex + offset]
 }
 
-const getPermalink = (data) =>
+const permalink = (data) =>
   isProdEnv() && isScheduled(data) ? false : `/${data.page.fileSlug}/`
 
-const getTitle = (data) =>
+const title = (data) =>
   `${data.page.fileSlug} ${char.ndash} ${data.title}${char.nbsp}${data.emoji}`
 
 module.exports = {
   layout: 'Episode',
   eleventyComputed: {
     nextEpisode: getAdjacentEpisode(-1),
-    permalink: getPermalink,
+    permalink,
     previousEpisode: getAdjacentEpisode(+1),
-    title: getTitle,
+    title,
   },
 }

--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -14,12 +14,17 @@ const previousEpisode = (data) => adjacentEpisode(data, +1)
 const permalink = (data) =>
   isProdEnv() && isScheduled(data) ? false : `/${data.page.fileSlug}/`
 
+function eleventyExcludeFromCollections(data) {
+  return permalink(data) === false
+}
+
 const title = (data) =>
   `${data.page.fileSlug} ${char.ndash} ${data.title}${char.nbsp}${data.emoji}`
 
 module.exports = {
   layout: 'Episode',
   eleventyComputed: {
+    eleventyExcludeFromCollections,
     nextEpisode,
     permalink,
     previousEpisode,


### PR DESCRIPTION
I had forgotten to set `eleventyExcludeFromCollections` to `false` for scheduled episodes so the sitemap had a bunch of `false` URLs (the permalink is `false` for scheduled episodes). 😵