### PR TITLE
Switch to ES Modules

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,1 +1,3 @@
-module.exports = require('./eleventy/config')
+import config from './eleventy/config'
+
+export default config

--- a/.esmrc.json
+++ b/.esmrc.json
@@ -1,0 +1,5 @@
+{
+  "cjs": {
+    "dedefault": true
+  }
+}

--- a/content/episodes/episodes.11tydata.js
+++ b/content/episodes/episodes.11tydata.js
@@ -1,5 +1,5 @@
-const char = require('$/data/char')
-const { isProdEnv, isScheduled } = require('$/data/utils')
+import char from '$/data/char'
+import { isProdEnv, isScheduled } from '$/data/utils'
 
 const adjacentEpisode = (data, offset) => {
   const { episodes } = data.collections
@@ -21,7 +21,7 @@ function eleventyExcludeFromCollections(data) {
 const title = (data) =>
   `${data.page.fileSlug} ${char.ndash} ${data.title}${char.nbsp}${data.emoji}`
 
-module.exports = {
+export default {
   layout: 'Episode',
   eleventyComputed: {
     eleventyExcludeFromCollections,

--- a/content/robots.11ty.js
+++ b/content/robots.11ty.js
@@ -1,6 +1,6 @@
-const dedent = require('dedent')
+import dedent from 'dedent'
 
-module.exports = class {
+export default class {
   data() {
     return {
       eleventyExcludeFromCollections: true,

--- a/content/sitemap.11ty.js
+++ b/content/sitemap.11ty.js
@@ -1,4 +1,4 @@
-module.exports = class {
+export default class {
   data() {
     return {
       eleventyExcludeFromCollections: true,

--- a/data/char.js
+++ b/data/char.js
@@ -11,7 +11,7 @@
  * - Some characters are impossible to see.
  *   E.g. zero-width joiner.
  */
-module.exports = {
+export default {
   copy: '©',
   nbsp: ' ', // non-breaking space
   ndash: '–', // en dash

--- a/data/utils.js
+++ b/data/utils.js
@@ -1,9 +1,7 @@
-function isProdEnv() {
+export function isProdEnv() {
   return process.env.NODE_ENV === 'production'
 }
 
-function isScheduled(data) {
+export function isScheduled(data) {
   return data.date > Date.now()
 }
-
-module.exports = { isProdEnv, isScheduled }

--- a/eleventy/browserSync.js
+++ b/eleventy/browserSync.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
+import { readFileSync } from 'fs'
 
-module.exports = (config) => {
+export default (config) => {
   // See https://browsersync.io/docs/options for all options
   config.setBrowserSyncConfig({
     callbacks: {
@@ -8,7 +8,7 @@ module.exports = (config) => {
         // Provides the 404 content without redirect. Original source:
         // https://github.com/11ty/eleventy-base-blog/blob/v5.0.2/.eleventy.js#L56-L64
         browserSync.addMiddleware('*', (req, res) => {
-          const notFoundContent = fs.readFileSync('./_site/404.html')
+          const notFoundContent = readFileSync('./_site/404.html')
           res.write(notFoundContent)
           res.end()
         })

--- a/eleventy/browserSync.js
+++ b/eleventy/browserSync.js
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import fs from 'fs'
 
 export default (config) => {
   // See https://browsersync.io/docs/options for all options
@@ -8,7 +8,7 @@ export default (config) => {
         // Provides the 404 content without redirect. Original source:
         // https://github.com/11ty/eleventy-base-blog/blob/v5.0.2/.eleventy.js#L56-L64
         browserSync.addMiddleware('*', (req, res) => {
-          const notFoundContent = readFileSync('./_site/404.html')
+          const notFoundContent = fs.readFileSync('./_site/404.html')
           res.write(notFoundContent)
           res.end()
         })

--- a/eleventy/collections.js
+++ b/eleventy/collections.js
@@ -1,6 +1,6 @@
-const { isProdEnv, isScheduled } = require('../data/utils')
+import { isProdEnv, isScheduled } from '../data/utils'
 
-module.exports = (config) => {
+export default (config) => {
   config.addCollection('episodes', (collectionApi) =>
     collectionApi
       .getFilteredByGlob('./content/episodes/*.md')

--- a/eleventy/config.js
+++ b/eleventy/config.js
@@ -1,8 +1,8 @@
-const setupBrowserSync = require('./browserSync')
-const setupCollections = require('./collections')
-const setupPreact = require('./preact')
+import setupBrowserSync from './browserSync'
+import setupCollections from './collections'
+import setupPreact from './preact'
 
-module.exports = (config) => {
+export default (config) => {
   setupBrowserSync(config)
   setupCollections(config)
   setupPreact(config)

--- a/eleventy/preact.js
+++ b/eleventy/preact.js
@@ -1,20 +1,15 @@
-require('react')
+import 'react'
 
-const { content } = require('@twind/content')
-const { default: typography } = require('@twind/typography')
-const path = require('path')
-const { isValidElement, VNode } = require('preact')
-const PreactCompat = require('preact/compat')
-const { render } = require('preact-render-to-string')
-const { apply, setup } = require('twind')
-const {
-  getStyleTag,
-  shim,
-  virtualSheet,
-  VirtualSheet,
-} = require('twind/shim/server')
+import { content } from '@twind/content'
+import typography from '@twind/typography'
+import path from 'path'
+import { isValidElement } from 'preact'
+import PreactCompat from 'preact/compat'
+import { render } from 'preact-render-to-string'
+import { apply, setup } from 'twind'
+import { getStyleTag, shim, virtualSheet } from 'twind/shim/server'
 
-module.exports = (config) => {
+export default (config) => {
   disableViewsCache(config)
   patchPreact()
   const sheet = setupTwind()

--- a/eleventy/preact.js
+++ b/eleventy/preact.js
@@ -77,7 +77,7 @@ function patchPreact() {
  * NOTE: The watch mode must be restarted after modifying these.
  * (This applies to all 11ty config files.)
  *
- * @returns {VirtualSheet}
+ * @returns {import('twind/shim/server').VirtualSheet}
  * Twind's virtual sheet.
  */
 function setupTwind() {
@@ -116,11 +116,11 @@ function setupTwind() {
  * Convert `htm` to HTML
  * and generate styles using Twind.
  *
- * @param {VNode<{}>} content
+ * @param {import('preact').VNode<{}>} content
  * The layout's contents,
  * so in this case a Preact VNode.
  *
- * @param {VirtualSheet} sheet
+ * @param {import('twind/shim/server').VirtualSheet} sheet
  * Twind's virtual sheet.
  *
  * @returns {string}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "basetag": "^2.0.1",
         "cross-env": "^7.0.3",
         "dedent": "^0.7.0",
+        "esm": "^3.2.25",
         "htm": "^3.0.4",
         "preact": "^10.5.13",
         "preact-render-to-string": "^5.1.19",
@@ -1087,6 +1088,14 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/esprima": {
@@ -4521,6 +4530,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esprima": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
-    "build": "npm run clean && cross-env NODE_ENV=production npx @11ty/eleventy",
+    "build": "npm run clean && cross-env NODE_ENV=production node --require=esm ./node_modules/\\@11ty/eleventy/cmd.js",
     "clean": "rm -rf ./_site/",
     "postinstall": "npx basetag link --hook",
-    "start": "npm run clean && cross-env NODE_ENV=development npx @11ty/eleventy --serve"
+    "start": "npm run clean && cross-env NODE_ENV=development node --require=esm ./node_modules/\\@11ty/eleventy/cmd.js --serve"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",
@@ -13,6 +13,7 @@
     "basetag": "^2.0.1",
     "cross-env": "^7.0.3",
     "dedent": "^0.7.0",
+    "esm": "^3.2.25",
     "htm": "^3.0.4",
     "preact": "^10.5.13",
     "preact-render-to-string": "^5.1.19",

--- a/views/components/Base.js
+++ b/views/components/Base.js
@@ -25,7 +25,7 @@ const Header = ({ currentUrl }) => {
                 <${Link}
                   class=${tw(
                     linkClasses,
-                    currentUrl.startsWith?.(href) && 'font-bold'
+                    currentUrl && currentUrl.startsWith(href) && 'font-bold'
                   )}
                   href=${href}
                 >

--- a/views/components/Base.js
+++ b/views/components/Base.js
@@ -1,9 +1,9 @@
-const { html } = require('htm/preact')
-const { tw } = require('twind')
+import { html } from 'htm/preact'
+import { tw } from 'twind'
 
-const char = require('$/data/char')
-const Link = require('./Link')
-const MaxWidth = require('./MaxWidth')
+import char from '$/data/char'
+import Link from './Link'
+import MaxWidth from './MaxWidth'
 
 const Header = ({ currentUrl }) => {
   const linkClasses = 'no-underline -mx-1 p-1 rounded hover:bg-gray-100'
@@ -46,7 +46,7 @@ const Footer = () => html`
   </footer>
 `
 
-module.exports = ({
+export default ({
   children,
   description,
   metaDescription,

--- a/views/components/EpisodeMeta.js
+++ b/views/components/EpisodeMeta.js
@@ -1,9 +1,9 @@
-const {
+import {
   CalendarIcon,
   ClockIcon,
   MicrophoneIcon,
-} = require('@heroicons/react/outline')
-const { html } = require('htm/preact')
+} from '@heroicons/react/outline'
+import { html } from 'htm/preact'
 
 const dateFormat = {
   human: (date) => date.toLocaleString('fi', { dateStyle: 'short' }),
@@ -50,7 +50,7 @@ const durationFormat = {
   },
 }
 
-module.exports = ({ date, duration, large = false, recorded }) => {
+export default ({ date, duration, large = false, recorded }) => {
   const iconSize = large ? 5 : 4
   const iconProps = {
     'aria-hidden': true,

--- a/views/components/Link.js
+++ b/views/components/Link.js
@@ -1,7 +1,7 @@
-const { html } = require('htm/preact')
-const { apply, tw } = require('twind')
+import { html } from 'htm/preact'
+import { apply, tw } from 'twind'
 
-module.exports = ({ children, class: classes = '', href, ...rest }) => html`
+export default ({ children, class: classes = '', href, ...rest }) => html`
   <a
     class=${tw(classes, apply('underline text-red(hover:600 active:700)'))}
     href=${href}

--- a/views/components/Markdown.js
+++ b/views/components/Markdown.js
@@ -1,5 +1,5 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-module.exports = ({ content }) => html`
+export default ({ content }) => html`
   <div dangerouslySetInnerHTML=${{ __html: content }} />
 `

--- a/views/components/MaxWidth.js
+++ b/views/components/MaxWidth.js
@@ -1,5 +1,5 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-module.exports = ({ as = 'div', children, class: classes = '' }) => html`
+export default ({ as = 'div', children, class: classes = '' }) => html`
   <${as} class="max-w(lg md:2xl) mx-auto w-full ${classes}">${children}<//>
 `

--- a/views/components/Player.js
+++ b/views/components/Player.js
@@ -1,8 +1,8 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-const char = require('$/data/char')
+import char from '$/data/char'
 
-module.exports = () => html`
+export default () => html`
   <p class="italic">
     Soitin tulossa pian${char.trade}! Sitä ennen voit kuunnella podia mm.${' '}
     <a href="https://open.spotify.com/show/1st4zWhHxzXn345vqdTfk8">

--- a/views/layouts/404.11ty.js
+++ b/views/layouts/404.11ty.js
@@ -1,10 +1,10 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-const Base = require('../components/Base')
-const Markdown = require('../components/Markdown')
-const MaxWidth = require('../components/MaxWidth')
+import Base from '../components/Base'
+import Markdown from '../components/Markdown'
+import MaxWidth from '../components/MaxWidth'
 
-module.exports = (data) => {
+export default (data) => {
   const { content, title } = data
 
   return html`

--- a/views/layouts/Episode.11ty.js
+++ b/views/layouts/Episode.11ty.js
@@ -1,13 +1,13 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-const Base = require('../components/Base')
-const EpisodeMeta = require('../components/EpisodeMeta')
-const Link = require('../components/Link')
-const Markdown = require('../components/Markdown')
-const MaxWidth = require('../components/MaxWidth')
-const Player = require('../components/Player')
+import Base from '../components/Base'
+import EpisodeMeta from '../components/EpisodeMeta'
+import Link from '../components/Link'
+import Markdown from '../components/Markdown'
+import MaxWidth from '../components/MaxWidth'
+import Player from '../components/Player'
 
-module.exports = (data) => {
+export default (data) => {
   const {
     date,
     description,

--- a/views/layouts/Home.11ty.js
+++ b/views/layouts/Home.11ty.js
@@ -1,11 +1,11 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-const char = require('$/data/char')
-const Base = require('../components/Base')
-const EpisodeMeta = require('../components/EpisodeMeta')
-const Link = require('../components/Link')
-const MaxWidth = require('../components/MaxWidth')
-const Player = require('../components/Player')
+import char from '$/data/char'
+import Base from '../components/Base'
+import EpisodeMeta from '../components/EpisodeMeta'
+import Link from '../components/Link'
+import MaxWidth from '../components/MaxWidth'
+import Player from '../components/Player'
 
 const LatestEpisode = ({
   data: { description, duration, recorded, title },
@@ -49,7 +49,7 @@ const Episode = ({
   </article>
 `
 
-module.exports = (data) => {
+export default (data) => {
   const {
     collections: { episodes },
     title,

--- a/views/layouts/Info.11ty.js
+++ b/views/layouts/Info.11ty.js
@@ -1,10 +1,10 @@
-const { html } = require('htm/preact')
+import { html } from 'htm/preact'
 
-const Base = require('../components/Base')
-const Markdown = require('../components/Markdown')
-const MaxWidth = require('../components/MaxWidth')
+import Base from '../components/Base'
+import Markdown from '../components/Markdown'
+import MaxWidth from '../components/MaxWidth'
 
-module.exports = (data) => {
+export default (data) => {
   const { content, description, title } = data
 
   return html`


### PR DESCRIPTION
[11ty doesn't support ES Modules](https://github.com/11ty/eleventy/issues/836), so we need to use [`esm`](https://github.com/standard-things/esm). Kudos to Lenny Anders for his [comment about how to setup 11ty + `esm`](https://github.com/11ty/eleventy/issues/836#issuecomment-643603107).

ES Modules are nice, but I don't know whether we should merge this or wait for 11ty to support them natively (without `esm`). 🤔 [`esm` doesn't support optional chaining syntax](https://github.com/standard-things/esm/issues/866), it has other open issues as well, and it hasn't been updated for two years. I fear that we could at some point get problems that are hard to fix because `esm` is in unmaintained status.

**Edit:** On the other hand, ES Modules would make implementing (partial) Preact hydration much easier, so I think I'll merge this. 😀 Let's hope that 11ty starts supporting ES Modules soon so we can ditch `esm`.