### PR TITLE
Add source code link to footer

### DIFF
--- a/src/js/components/Base.js
+++ b/src/js/components/Base.js
@@ -43,7 +43,12 @@ const Header = ({ currentUrl }) => {
 
 const Footer = () => html`
   <footer class="mt-auto py-8 text-gray-600">
-    <${MaxWidth} class="border-t-2 pt-8">${char.copy} Koodikrapula 2021<//>
+    <${MaxWidth} class="border-t-2 pt-8 flex justify-between">
+      <div>${char.copy} Koodikrapula 2021</div>
+      <div>
+        <a href="https://github.com/koodikrapula/koodikrapula.fi">Lähdekoodi</a>
+      </div>
+    <//>
   </footer>
 `
 

--- a/src/js/components/Base.js
+++ b/src/js/components/Base.js
@@ -44,10 +44,12 @@ const Header = ({ currentUrl }) => {
 const Footer = () => html`
   <footer class="mt-auto py-8 text-gray-600">
     <${MaxWidth} class="border-t-2 pt-8 flex justify-between">
-      <div>${char.copy} Koodikrapula 2021</div>
-      <div>
-        <a href="https://github.com/koodikrapula/koodikrapula.fi">Lähdekoodi</a>
-      </div>
+      <p>${char.copy} Koodikrapula 2021</p>
+      <p>
+        <${Link} href="https://github.com/koodikrapula/koodikrapula.fi">
+          Lähdekoodi
+        <//>
+      </p>
     <//>
   </footer>
 `


### PR DESCRIPTION
Fixes #67 

Only 'lähdekoodi' as test (instead of 'Sivuston lähdekoodi GitHubissa →') because it should be pretty obvious which source code it links to