### PR TITLE
Simplify ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
   extends: [
     'airbnb-base',
     'plugin:eslint-comments/recommended',
-    'plugin:sonarjs/recommended',
 
     // This should probably come last
     'prettier',
@@ -32,7 +31,7 @@ module.exports = {
     ecmaVersion: 2021,
     sourceType: 'module',
   },
-  plugins: ['simple-import-sort', 'sonarjs', 'unicorn'],
+  plugins: ['simple-import-sort', 'unicorn'],
   rules: {
     /* BUILT-IN RULES */
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
     {
       files: 'scripts/*.js',
       rules: {
-        'no-console': 'off',
         'unicorn/no-process-exit': 'off',
       },
     },
@@ -32,23 +31,42 @@ module.exports = {
   },
   plugins: ['simple-import-sort', 'unicorn'],
   rules: {
-    /* BUILT-IN RULES */
+    /* BUILT-IN RULES: "Possible Problems"
+     * https://eslint.org/docs/rules/#possible-problems
+     */
 
-    // Allow function hoisting
-    // because sometimes it makes things clearer
+    'array-callback-return': 'warn',
+    'no-template-curly-in-string': 'warn',
+
+    // Functions are hoisted, classes and variables are not
     'no-use-before-define': [
       'error',
       { functions: false, classes: true, variables: true },
     ],
 
-    // Allow concatenating strings with `+`
-    // because sometimes it's clearer than template strings
-    'prefer-template': 'off',
+    /* BUILT-IN RULES: "Suggestions"
+     * https://eslint.org/docs/rules/#suggestions
+     */
 
-    /* PRETTIER
-     *
-     * These Airbnb rules need to be re-defined
-     * because the Prettier plugin's rules override them
+    curly: ['error', 'multi-line', 'consistent'],
+    'consistent-return': 'warn',
+    'dot-notation': 'error',
+
+    // `== null` checks against `null` and `undefined`.
+    // In other cases `===` should be used.
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
+
+    'no-array-constructor': 'error',
+    'no-else-return': 'error',
+    'no-implied-eval': 'error',
+    'no-lonely-if': 'error',
+    'no-sequences': ['error', { allowInParentheses: false }],
+    'no-shadow': 'warn',
+    'no-throw-literal': 'error',
+    'no-unneeded-ternary': 'warn',
+
+    /* BUILT-IN RULES: "Layout & Formatting"
+     * https://eslint.org/docs/rules/#layout-formatting
      */
 
     quotes: ['error', 'single', { avoidEscape: true }],
@@ -121,11 +139,7 @@ module.exports = {
     'unicorn/no-keyword-prefix': 'off',
 
     'unicorn/no-lonely-if': 'error',
-
-    // These two are related
-    'no-nested-ternary': 'off',
     'unicorn/no-nested-ternary': 'error',
-
     'unicorn/no-new-array': 'error',
     'unicorn/no-new-buffer': 'error',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,11 +5,10 @@ module.exports = {
     node: true,
   },
   extends: [
-    'airbnb-base',
+    'eslint:recommended',
+    'plugin:import/recommended',
     'plugin:eslint-comments/recommended',
-
-    // This should probably come last
-    'prettier',
+    'prettier', // This should probably come last
   ],
   ignorePatterns: ['!.eleventy.js'],
   overrides: [

--- a/eleventy/preact.js
+++ b/eleventy/preact.js
@@ -83,7 +83,7 @@ function disableComponentCache(config) {
  * The v10 docs are missing similar instructions for some reason.
  */
 function patchPreact() {
-  // eslint-disable-next-line no-underscore-dangle, unicorn/prefer-module
+  // eslint-disable-next-line unicorn/prefer-module
   module.constructor._cache[require.resolve('react')].exports = PreactCompat
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "eslint-plugin-sonarjs": "^0.8.0-125",
         "eslint-plugin-unicorn": "^33.0.1",
         "esm": "^3.2.25",
         "gray-matter": "^4.0.3",
@@ -2102,17 +2101,6 @@
       "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
       "peerDependencies": {
         "eslint": ">=5.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-sonarjs": {
-      "version": "0.8.0-125",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.8.0-125.tgz",
-      "integrity": "sha512-/nl3Yzy8cHxCj5ohQL8dEqK2AhQqjTM/oXz5K3bU/7XbsBTz0BgyEsDvdz7gdtRlAe0Hzrf2v3qLVHA506Qheg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -7607,12 +7595,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
       "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
-      "requires": {}
-    },
-    "eslint-plugin-sonarjs": {
-      "version": "0.8.0-125",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.8.0-125.tgz",
-      "integrity": "sha512-/nl3Yzy8cHxCj5ohQL8dEqK2AhQqjTM/oXz5K3bU/7XbsBTz0BgyEsDvdz7gdtRlAe0Hzrf2v3qLVHA506Qheg==",
       "requires": {}
     },
     "eslint-plugin-unicorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cross-env": "^7.0.3",
         "dedent": "^0.7.0",
         "eslint": "^7.29.0",
-        "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.22.1",
@@ -1302,11 +1301,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA=="
-    },
     "node_modules/connect": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -1884,23 +1878,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-        "eslint-plugin-import": "^2.22.1"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -3917,19 +3894,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
@@ -6959,11 +6923,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "confusing-browser-globals": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA=="
-    },
     "connect": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -7426,16 +7385,6 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
-      }
-    },
-    "eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
-      "requires": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
       }
     },
     "eslint-config-prettier": {
@@ -8916,16 +8865,6 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
-      }
-    },
-    "object.entries": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
       }
     },
     "object.values": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "cross-env": "^7.0.3",
     "dedent": "^0.7.0",
     "eslint": "^7.29.0",
-    "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "eslint-plugin-sonarjs": "^0.8.0-125",
     "eslint-plugin-unicorn": "^33.0.1",
     "esm": "^3.2.25",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
- Remove eslint-plugin-sonarjs
  - I don't think it provided any extra value
- Remove eslint-config-airbnb-base
  - I had used it out of habit. It's OK I think, but it also has some annoying rules
- Extend `eslint:recommended` instead
  - This enables rules marked with "✓" on [ESLint's _List of available rules_ page](https://eslint.org/docs/rules/)
- Extend `plugin:import/recommended` as well
  - Previously the import plugin's rules were configured by the Airbnb config
- Enable some other rules as well
  - I skimmed the rules page and enabled a couple of rules that looked useful
  - Later it would be good to find an alternative to the Airbnb config _or_ check and configure all rules manually

TL;DR: Now less rules are enabled, but hopefully still enough.